### PR TITLE
Add support for Xcode image assets.

### DIFF
--- a/tagIcons.sh
+++ b/tagIcons.sh
@@ -8,7 +8,11 @@ tagMode="tag"
 cleanupMode="cleanup"
 
 iconsDirectory=`cd $2 && pwd`
-icons=(`/usr/libexec/PlistBuddy -c "Print CFBundleIconFiles" "${INFOPLIST_FILE}" | grep png | tr -d '\n'`)
+if [ $(echo "${iconsDirectory}" | grep -E "\.appiconset$") ]; then
+	icons=(`grep 'filename' "${iconsDirectory}/Contents.json" | cut -f2 -d: | tr -d ',' | tr -d '\n' | tr -d '"'`)
+else
+	icons=(`/usr/libexec/PlistBuddy -c "Print CFBundleIconFiles" "${INFOPLIST_FILE}" | grep png | tr -d '\n'`)
+fi
 
 taggerDirectory=`dirname $0`
 taggerPlist="tagImage.workflow/Contents/document.wflow"


### PR DESCRIPTION
To use it, just pass in the path to (and including) Images.xcassets/AppIcon.appiconset as the 2nd parameter. The script will check if it ends in .appiconset and behave accordingly.
Behaviour for icons referenced directly from the Info.plist has not been changed.
