### PR TITLE
Combine version from CFBundleShortVersion and CFBundleVersion

### DIFF
--- a/tagIcons.sh
+++ b/tagIcons.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 commit=`git rev-parse --short HEAD`
-version=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${INFOPLIST_FILE}"`
+version1=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${INFOPLIST_FILE}"`
+version2=`/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "${INFOPLIST_FILE}"`
+version="${version1} [${version2}]"
 
 mode=$1
 tagMode="tag"
@@ -30,7 +32,7 @@ do
 
                 cd $taggerDirectory
                 /usr/libexec/PlistBuddy -c "Set $paramsPath:renderPixelsHigh $renderSize" -c "Set $paramsPath:renderPixelsWide $renderSize" $taggerPlist
-                automator -D text=$version$'\n'$commit -D image=$icon -i tagImage.qtz tagImage.workflow > /dev/null
+                automator -D text="$version"$'\n'"$commit" -D image="$icon" -i tagImage.qtz tagImage.workflow > /dev/null
                 git checkout $taggerPlist
 
                 sips --cropToHeightWidth $height $width tagImage.png > /dev/null


### PR DESCRIPTION
Our builds increment the CFBundleVersion for each build. For betas
it helps us to see version numbers like "1.0 [22]" in the icon, with
1.0 being the short version and 22 the bundle version counter.

Also modified the automator call to handle the spaces in the version
variable correctly.
