### PR TITLE
Add custom command, split existing tag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,35 @@
+# XcodeIconTagger
 
-XcodeIconTagger
-===============
-
-The XcodeIconTagger can add a version number and a GIT commit hash (or any other text) as an overlay to your iOS app's icon. This can be really useful for beta/AdHoc builds, just a glimpse at Springboard can reveal which version of your app is installed on a device! The idea for this tool came from Evan Doll who presented it at NSConference #5 as a part of development setup that Flipboard is using.
+`XcodeIconTagger` can add a version number, git commit hash or custom text as an overlay to your iOS app's icon. This can be really useful for beta or ad hoc builds, just a glimpse at Springboard can reveal which version of your app is installed on a device! The idea for this tool came from Evan Doll who presented it at NSConference #5 as a part of development setup that Flipboard is using.
 
 ## Usage
 
 The entry point of the tagger is tagIcons.sh script, which takes two arguments:
 
-	tagIcons.sh <command> [path-to-icons-directory]
-	
+	tagIcons.sh <command> /path/to/.../<icons-directory> [optional-custom-tag]
+
 The available commands are:
 
-* _tag_ - tags icons with version number and commit hash
-* _custom_ - tags icons with a custom string, provided in the script command
-* _cleanup_ - checkouts the icons to their original state
+* `commit` - tag icons with git commit hash
+* `version` - tag icons with semantic+build version string
+* `custom` - tag icons with a custom string, provided at the end of the command
+* `cleanup` - restore the icons to their original state by performing a git checkout on their directory
 
-The script is designed to be run as one of Xcode build phases. It uses environmental variables to retrieve application version and icons file names from application's Info Plist file (since the plist doesn't include full paths you still need to provide the base path to icons directory).
+The easiest way to use `XcodeIconTagger` is from a _Run Script_ Build Phase in Xcode, where it grabs the location of the application's Info.plist file. Place an invocation like the following somewhere before the _Copy Files_ Build Phase that copies the directory containing your icons:
 
-The easiest way to integrate XcodeIconTagger with your project is by adding two scripts to build phases, one at the very beginning:
-
-	if [ $CONFIGURATION == "Release" ] ; then
-    	${SRCROOT}/XcodeIconTagger/tagIcons.sh tag MyApp/Images
+	if [ $CONFIGURATION == "Debug" ] ; then
+		/path/to/.../tagIcons.sh commit /path/to/.../<icons-directory>
+	elif [ $CONFIGURATION == "Release" ] ; then
+		/path/to/.../tagIcons.sh version /path/to/.../<icons-directory>
 	fi
 
 If instead of version/hash info in the tag, you want to put "My custom string":
 
-	if [ $CONFIGURATION == "Release" ] ; then
-    	${SRCROOT}/XcodeIconTagger/tagIcons.sh custom MyApp/Images "My custon string"
-	fi
+	/path/to/.../tagIcons.sh custom /path/to/.../<icons-directory> "My custom string"
 
-and one at the very end:
+Then, somewhere after the _Copy Files_ Build Phase for icons:
 
-	if [ $CONFIGURATION == "Release" ] ; then
-	    ${SRCROOT}/XcodeIconTagger/tagIcons.sh cleanup MyApp/Images
-	fi
+	/path/to/.../tagIcons.sh cleanup /path/to/.../<icons-directory>
 
 ## Sample tagged icon
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The entry point of the tagger is tagIcons.sh script, which takes two arguments:
 
 	tagIcons.sh <command> [path-to-icons-directory]
 	
-The two available commands are:
+The available commands are:
 
 * _tag_ - tags icons with version number and commit hash
+* _custom_ - tags icons with a custom string, provided in the script command
 * _cleanup_ - checkouts the icons to their original state
 
 The script is designed to be run as one of Xcode build phases. It uses environmental variables to retrieve application version and icons file names from application's Info Plist file (since the plist doesn't include full paths you still need to provide the base path to icons directory).
@@ -21,6 +22,12 @@ The easiest way to integrate XcodeIconTagger with your project is by adding two 
 
 	if [ $CONFIGURATION == "Release" ] ; then
     	${SRCROOT}/XcodeIconTagger/tagIcons.sh tag MyApp/Images
+	fi
+
+If instead of version/hash info in the tag, you want to put "My custom string":
+
+	if [ $CONFIGURATION == "Release" ] ; then
+    	${SRCROOT}/XcodeIconTagger/tagIcons.sh custom MyApp/Images "My custon string"
 	fi
 
 and one at the very end:

--- a/tagIcons.sh
+++ b/tagIcons.sh
@@ -8,6 +8,7 @@ version="${version1} [${version2}]"
 mode=$1
 tagMode="tag"
 cleanupMode="cleanup"
+customTagMode="custom"
 
 taggerDirectory=`dirname $0`
 taggerPlist="tagImage.workflow/Contents/document.wflow"
@@ -32,13 +33,18 @@ do
         width=`sips -g pixelWidth $icon | tail -n 1 | sed "s/ *pixelWidth: */ /"`
 
         if (( $height == $width )); then
-            if [ $mode == $tagMode ]; then
+            if [[ $mode = $tagMode || $mode = $customTagMode ]]; then
                 renderSize=$(( $width * 4 )) # for some reason it looks much better when rendering canvas are bigger than an icon
                 renderSize=$(( $renderSize + $width%2 )) # rendering canvas for odd sized images should also be odd
 
                 cd $taggerDirectory
                 /usr/libexec/PlistBuddy -c "Set $paramsPath:renderPixelsHigh $renderSize" -c "Set $paramsPath:renderPixelsWide $renderSize" $taggerPlist
-                automator -D text="$version"$'\n'"$commit" -D image="$icon" -i tagImage.qtz tagImage.workflow > /dev/null
+                if [[ $mode = $tagMode ]]; then
+                    textContent="$version"$'\n'"$commit"
+                elif [[ $mode = $customTagMode ]]; then
+                    textContent="$3"
+                fi
+                automator -D text="$textContent" -D image="$icon" -i tagImage.qtz tagImage.workflow > /dev/null
                 git checkout $taggerPlist
 
                 sips --cropToHeightWidth $height $width tagImage.png > /dev/null

--- a/tagIcons.sh
+++ b/tagIcons.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-commit=`git rev-parse --short HEAD`
-version1=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${INFOPLIST_FILE}"`
-version2=`/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "${INFOPLIST_FILE}"`
-version="${version1} [${version2}]"
+# get the mode parameter
 
 mode=$1
-tagMode="tag"
+commitMode="commit"
+versionMode="version"
+customMode="custom"
 cleanupMode="cleanup"
-customTagMode="custom"
+
+# get version info from plist in case we need it later, before we change directories
+version1=`/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${INFOPLIST_FILE}"`
+version2=`/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "${INFOPLIST_FILE}"`
+version="${version1}+${version2}"
+
+# locate icons with path parameter
 
 taggerDirectory=`dirname $0`
 taggerPlist="tagImage.workflow/Contents/document.wflow"
@@ -22,7 +27,6 @@ else
 	icons=(`/usr/libexec/PlistBuddy -c "Print CFBundleIconFiles" "${INFOPLIST_FILE}" | grep png | tr -d '\n'`)
 fi
 
-
 iconsCount=${#icons[*]}
 for (( i=0; i<iconsCount; i++ ))
 do
@@ -33,20 +37,24 @@ do
         width=`sips -g pixelWidth $icon | tail -n 1 | sed "s/ *pixelWidth: */ /"`
 
         if (( $height == $width )); then
-            if [[ $mode = $tagMode || $mode = $customTagMode ]]; then
+            if [[ $mode = $versionMode || $mode = $customMode || $mode = $commitMode ]]; then
                 renderSize=$(( $width * 4 )) # for some reason it looks much better when rendering canvas are bigger than an icon
                 renderSize=$(( $renderSize + $width%2 )) # rendering canvas for odd sized images should also be odd
+                
+                # prepare the text for the overlay
+                if [[ $mode = $versionMode ]]; then
+                    textContent="$version"
+                elif [[ $mode = $commitMode ]]; then
+                    textContent=`git rev-parse --short HEAD`
+                    echo $textContent
+                elif [[ $mode = $customMode ]]; then
+                    textContent="$3"
+                fi
 
                 cd $taggerDirectory
                 /usr/libexec/PlistBuddy -c "Set $paramsPath:renderPixelsHigh $renderSize" -c "Set $paramsPath:renderPixelsWide $renderSize" $taggerPlist
-                if [[ $mode = $tagMode ]]; then
-                    textContent="$version"$'\n'"$commit"
-                elif [[ $mode = $customTagMode ]]; then
-                    textContent="$3"
-                fi
                 automator -D text="$textContent" -D image="$icon" -i tagImage.qtz tagImage.workflow > /dev/null
                 git checkout $taggerPlist
-
                 sips --cropToHeightWidth $height $width tagImage.png > /dev/null
                 mv tagImage.png $icon
             elif [ $mode == $cleanupMode ]; then


### PR DESCRIPTION
Hey, I found your tool and love it! I modified it a bit for my purposes, and thought I'd offer up my ideas back to you. Feel free to do whatever you like with them.

- split `tag` command into `commit` and `version`. I only wanted one or the other between debugging/dev builds and beta builds.
- added `custom` command to place arbitrary text on an icon
- updated some wording/formatting in the readme